### PR TITLE
ヘッダーの作成(コンポーネント分割)

### DIFF
--- a/src/components/atoms/button/MenuIconButton.tsx
+++ b/src/components/atoms/button/MenuIconButton.tsx
@@ -1,0 +1,15 @@
+import { HamburgerIcon } from '@chakra-ui/icons';
+import { IconButton } from '@chakra-ui/react';
+import React from 'react'
+import {memo,VFC} from "react";
+
+type Props = {
+    onOpen: () => void;
+}
+
+export const MenuIcomButton: VFC<Props> = memo((props) =>{
+    const {onOpen} = props;
+    return(
+        <IconButton aria-label='メニューボタン' size="sm" icon={<HamburgerIcon />} variant="unstyled" display={{base:"block",md:"none"}} onClick={onOpen} />
+    );
+});

--- a/src/components/molecules/MenuDrawer.tsx
+++ b/src/components/molecules/MenuDrawer.tsx
@@ -1,0 +1,25 @@
+import { Button, Drawer, DrawerBody, DrawerContent, DrawerOverlay } from '@chakra-ui/react';
+import React from 'react'
+import {memo,VFC} from "react";
+
+type Props = {
+    onClose: () => void;
+    isOpen: boolean;
+}
+
+export const MenuDrawer: VFC<Props> = memo((props) =>{
+    const {onClose,isOpen} = props;
+    return(
+    <Drawer placement='left'size="xs" onClose={onClose} isOpen={isOpen}>
+        <DrawerOverlay>
+            <DrawerContent>
+                <DrawerBody p={0} bg="gray.100">
+                    <Button w="100%">TOP</Button>
+                    <Button w="100%">ユーザー一覧</Button>
+                    <Button w="100%">設定</Button>
+                </DrawerBody>
+            </DrawerContent>
+        </DrawerOverlay>
+    </Drawer>
+    );
+});

--- a/src/components/oganisms/layout/Header.tsx
+++ b/src/components/oganisms/layout/Header.tsx
@@ -1,7 +1,8 @@
-import { Box, Button, Drawer, DrawerBody, DrawerContent, DrawerOverlay, Flex, Heading, IconButton, Link, useDisclosure } from '@chakra-ui/react';
-import {HamburgerIcon} from "@chakra-ui/icons";
+import { Box, Flex, Heading, Link, useDisclosure } from '@chakra-ui/react';
 import React from 'react'
 import { memo, VFC } from "react";
+import { MenuIcomButton } from '../../atoms/button/MenuIconButton';
+import { MenuDrawer } from '../../molecules/MenuDrawer';
 
 export const Header: VFC = memo(() =>{
     const { isOpen,onOpen,onClose } = useDisclosure();
@@ -18,19 +19,9 @@ export const Header: VFC = memo(() =>{
                 </Box>
                 <Link>設定</Link>
             </Flex>
-            <IconButton aria-label='メニューボタン' size="sm" icon={<HamburgerIcon />} variant="unstyled" display={{base:"block",md:"none"}} onClick={onOpen} />
+            <MenuIcomButton onOpen={onOpen} />
         </Flex>
-        <Drawer placement='left'size="xs" onClose={onClose} isOpen={isOpen}>
-            <DrawerOverlay>
-                <DrawerContent>
-                    <DrawerBody p={0} bg="gray.100">
-                        <Button w="100%">TOP</Button>
-                        <Button w="100%">ユーザー一覧</Button>
-                        <Button w="100%">設定</Button>
-                    </DrawerBody>
-                </DrawerContent>
-            </DrawerOverlay>
-        </Drawer>
+        <MenuDrawer onClose={onClose} isOpen={isOpen} />
     </>
     )
     ;


### PR DESCRIPTION
## やったこと
### ヘッダーの作成(コンポーネント分割)
・コードの煩雑化を防止するため、atomic designに基づいてコンポーネントを分割