### PR TITLE
ヘッダーのルーティングを設定

### DIFF
--- a/src/components/molecules/MenuDrawer.tsx
+++ b/src/components/molecules/MenuDrawer.tsx
@@ -5,18 +5,21 @@ import {memo,VFC} from "react";
 type Props = {
     onClose: () => void;
     isOpen: boolean;
+    onClickHome: () => void;
+    onClickSetting: () => void;
+    onClickUserManagement: () => void;
 }
 
 export const MenuDrawer: VFC<Props> = memo((props) =>{
-    const {onClose,isOpen} = props;
+    const {onClose,isOpen,onClickHome,onClickSetting,onClickUserManagement} = props;
     return(
     <Drawer placement='left'size="xs" onClose={onClose} isOpen={isOpen}>
         <DrawerOverlay>
             <DrawerContent>
                 <DrawerBody p={0} bg="gray.100">
-                    <Button w="100%">TOP</Button>
-                    <Button w="100%">ユーザー一覧</Button>
-                    <Button w="100%">設定</Button>
+                    <Button w="100%" onClick={onClickHome}>TOP</Button>
+                    <Button w="100%" onClick={onClickUserManagement}>ユーザー一覧</Button>
+                    <Button w="100%" onClick={onClickSetting}>設定</Button>
                 </DrawerBody>
             </DrawerContent>
         </DrawerOverlay>

--- a/src/components/oganisms/layout/Header.tsx
+++ b/src/components/oganisms/layout/Header.tsx
@@ -1,27 +1,32 @@
 import { Box, Flex, Heading, Link, useDisclosure } from '@chakra-ui/react';
-import React from 'react'
+import React, { useCallback } from 'react'
 import { memo, VFC } from "react";
+import { useHistory } from 'react-router-dom';
 import { MenuIcomButton } from '../../atoms/button/MenuIconButton';
 import { MenuDrawer } from '../../molecules/MenuDrawer';
 
 export const Header: VFC = memo(() =>{
     const { isOpen,onOpen,onClose } = useDisclosure();
+    const history = useHistory();
+    const onClickHome = useCallback( ()=> history.push("/home"),[history]);
+    const onClickSetting = useCallback( ()=> history.push("/home/setting"),[history]);
+    const onClickUserManagement = useCallback( ()=> history.push("/home/user_management"),[history]);
     return (
     <>
         <Flex as="nav" bg="teal.500" color="gray.50" align="center" justify="space-between" padding={{base:3,md:5}}>
-            <Flex align="center" as="a" mr={8} _hover={{cursor:"pointer"}}>
+            <Flex align="center" as="a" mr={8} _hover={{cursor:"pointer"}} onClick={onClickHome}>
               <Heading as="h1" fontSize={{base: "md", md:"lg"}}>ユーザー管理アプリ</Heading>
             </Flex>
                 
             <Flex align="center" fontSize="sm" flexGrow={2} display={{base:"none", md:"flex"}}>
                 <Box pr={4}>
-                    <Link>ユーザー一覧</Link>
+                    <Link onClick={onClickUserManagement}>ユーザー一覧</Link>
                 </Box>
-                <Link>設定</Link>
+                <Link onClick={onClickSetting}>設定</Link>
             </Flex>
             <MenuIcomButton onOpen={onOpen} />
         </Flex>
-        <MenuDrawer onClose={onClose} isOpen={isOpen} />
+        <MenuDrawer onClose={onClose} isOpen={isOpen} onClickHome={onClickHome} onClickSetting={onClickSetting} onClickUserManagement={onClickUserManagement} />
     </>
     )
     ;


### PR DESCRIPTION
## やったこと
### ヘッダーのルーティングを設定
・ヘッダーメニューのリンクに対してルーティングを設定し、ページ遷移が可能になった。
・スマホ画面のドロワーメニューも同様にルーティングを設定。